### PR TITLE
Build with QtCreator 4.3

### DIFF
--- a/RustEditor.json.in
+++ b/RustEditor.json.in
@@ -12,6 +12,17 @@
     \"Category\" : \"Other Languages\",
     \"Description\" : \"Rust editor component.\",
     \"Url\" : \"\",
-    $$dependencyList
+    $$dependencyList,
+
+    \"Mimetypes\" : \"
+    <?xml version=\'1.0\'?>
+    <mime-info xmlns=\'http://www.freedesktop.org/standards/shared-mime-info\'>
+        <mime-type type=\'text/x-rustsrc\'>
+            <sub-class-of type=\'text/x-csrc\'/>
+            <comment>Rust source code</comment>
+            <glob pattern=\'*.rs\'/>
+        </mime-type>
+    </mime-info>
+    \"
 }
 

--- a/RustEditor.mimetypes.xml
+++ b/RustEditor.mimetypes.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-    <mime-type type="text/x-rustsrc">
-        <sub-class-of type="text/x-csrc"/>
-        <comment>Rust source code</comment>
-        <glob pattern="*.rs"/>
-    </mime-type>
-</mime-info>

--- a/rustcompletionassist.cpp
+++ b/rustcompletionassist.cpp
@@ -216,7 +216,7 @@ IAssistProposal *RustCompletionAssistProcessor::perform(const AssistInterface *i
     //Keep the compatibility with 3.x until 4.0 is out
 #if (QTC_VERSION_MAJOR == 3) && (QTC_VERSION_MINOR == 6)
     QList<AssistProposalItem *> m_completions;
-#elif (QTC_VERSION_MAJOR == 4) && (QTC_VERSION_MINOR == 0)
+#elif (QTC_VERSION_MAJOR == 4) && (QTC_VERSION_MINOR >= 0)
     QList<AssistProposalItemInterface *> m_completions; // all possible completions at given point
 #endif
 

--- a/rusteditor.pro
+++ b/rusteditor.pro
@@ -28,23 +28,6 @@ HEADERS += rusteditorplugin.h \
 
 # Qt Creator linking
 
-## Set QTC Version
-QTC_MAJ = $$(QTC_MAJOR)
-QTC_MIN = $$(QTC_MINOR)
-isEmpty(QTC_MAJ) || isEmpty(QTC_MIN){
-    QTC_MAJ = $$QTC_MAJOR
-    QTC_MIN = $$QTC_MINOR
-}
-isEmpty(QTC_MAJ) || isEmpty(QTC_MIN){
-    QTC_MAJ = 3
-    QTC_MIN = 6
-}
-
-DEFINES += "QTC_VERSION_MAJOR=$${QTC_MAJ}"
-DEFINES += "QTC_VERSION_MINOR=$${QTC_MIN}"
-message("Target Qt Creator version: $${QTC_MAJ}.$${QTC_MIN}")
-
-
 ## set the QTC_SOURCE environment variable to override the setting here
 QTCREATOR_SOURCES = $$(QTC_SOURCE)
 isEmpty(QTCREATOR_SOURCES):QTCREATOR_SOURCES=$$QTC_SOURCE
@@ -91,6 +74,23 @@ QTC_PLUGIN_RECOMMENDS += \
 ###### End _dependencies.pri contents ######
 
 include($$QTCREATOR_SOURCES/src/qtcreatorplugin.pri)
+
+## Set QTC Version
+QTC_MAJ = $$(QTC_MAJOR)
+QTC_MIN = $$(QTC_MINOR)
+isEmpty(QTC_MAJ) || isEmpty(QTC_MIN){
+    QTC_MAJ = $$QTC_MAJOR
+    QTC_MIN = $$QTC_MINOR
+}
+isEmpty(QTC_MAJ) || isEmpty(QTC_MIN){
+    QTC_VERSIONS=$$split(QTCREATOR_VERSION, .)
+    QTC_MAJ = $$first(QTC_VERSIONS)
+    QTC_MIN = $$member(QTC_VERSIONS, 1)
+}
+
+DEFINES += "QTC_VERSION_MAJOR=$${QTC_MAJ}"
+DEFINES += "QTC_VERSION_MINOR=$${QTC_MIN}"
+message("Target Qt Creator version: $${QTC_MAJ}.$${QTC_MIN}")
 
 RESOURCES += \
     rusteditor.qrc

--- a/rusteditor.qrc
+++ b/rusteditor.qrc
@@ -1,6 +1,5 @@
 <RCC>
     <qresource prefix="/rusteditor">
-        <file>RustEditor.mimetypes.xml</file>
         <file>images/attribute.png</file>
         <file>images/const.png</file>
         <file>images/func.png</file>

--- a/rusteditorplugin.cpp
+++ b/rusteditorplugin.cpp
@@ -31,8 +31,6 @@
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/coreconstants.h>
 
-#include <utils/mimetypes/mimedatabase.h>
-
 #include <QAction>
 #include <QMessageBox>
 #include <QMainWindow>
@@ -69,8 +67,6 @@ bool RustEditorPlugin::initialize(const QStringList &arguments, QString *errorSt
     new Configuration(this);
 
     addAutoReleasedObject(new RustSettingsPage);
-
-    Utils::MimeDatabase::addMimeTypes(QLatin1String(":/rusteditor/RustEditor.mimetypes.xml"));
     addAutoReleasedObject(new RustEditorFactory);
 
     return true;

--- a/rustsettingspage.cpp
+++ b/rustsettingspage.cpp
@@ -31,7 +31,7 @@ RustSettingsPage::RustSettingsPage(QObject *parent):
     setDisplayName(tr("Rust Configurations"));
     setCategory(Constants::RUSTEDITOR_SETTINGS_CATEGORY);
     setDisplayCategory(QCoreApplication::translate("Rust",Constants::RUSTEDITOR_SETTINGS_TR_CATEGORY));
-    setCategoryIcon(QLatin1String(Constants::RUSTEDITOR_SETTINGS_CATEGORY_ICON));
+    setCategoryIcon(Utils::Icon(Constants::RUSTEDITOR_SETTINGS_CATEGORY_ICON));
 }
 
 QWidget *RustSettingsPage::widget()


### PR DESCRIPTION
- Fix QtCreator version detection
- Use 'AssistProposalItemInterface' for all 4.x branches
- Move mimemtypes declaration into plugin's JSON metadata
- Use Utils::Icon with Core::IOptionsPage::setCategoryIcon()